### PR TITLE
Allow to configure due date on tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+micro_manager-*.gem
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@
 .rspec_status
 
 micro_manager-*.gem
+*.swp
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -2,9 +2,11 @@
 
 require "tty-table"
 require_relative "micro_manager"
+require_relative "cli/relative_date"
 require_relative "cli/command_builder"
 require_relative "cli/add_task"
 require_relative "cli/list_tasks"
+require_relative "cli/show_help"
 
 module MicroManager
   module CLI

--- a/lib/cli/command_builder.rb
+++ b/lib/cli/command_builder.rb
@@ -1,24 +1,44 @@
 # frozen_string_literal: true
 
+require "optparse"
+
 module MicroManager
   module CLI
     class CommandBuilder
-      private attr_reader :context
-
-      def initialize
-      end
-
-      def build(options)
-        build_for_today(options)
+      def build(input)
+        params = parse_input(input)
+        build_for_today(params)
       end
 
       private
 
-      def build_for_today(options)
-        if options.empty?
+      def parse_input(input)
+        params = {}
+        rest = parser.parse(input, into: params)
+
+        params.merge(rest: rest)
+      end
+
+      def build_for_today(params)
+        if params[:help]
+          ShowHelp.new(parser)
+        elsif params[:"list-tasks"] || params[:rest].empty?
           ListTasks.new
         else
-          AddTask.new(description: options.join(" "))
+          task = { description: params[:rest].join(" ") }
+          task.merge!(due: params[:due]) if params[:due]
+          AddTask.new(**task)
+        end
+      end
+
+      def parser
+        OptionParser.new do |opts|
+          opts.accept(RelativeDate) do |date|
+            RelativeDate.parse(date)
+          end
+          opts.on("-d", "--due [DATE]", RelativeDate, "Date to which the task is due, defaults to Date.today. Supports relative dates (e.g. 1-day, 2-weeks, etc)")
+          opts.on("-l", "--list-tasks", "Lists all due tasks and tasks completed today")
+          opts.on("-h", "--help", "Prints this help")
         end
       end
     end

--- a/lib/cli/command_builder.rb
+++ b/lib/cli/command_builder.rb
@@ -7,19 +7,7 @@ module MicroManager
     class CommandBuilder
       def build(input)
         params = parse_input(input)
-        build_for_today(params)
-      end
 
-      private
-
-      def parse_input(input)
-        params = {}
-        rest = parser.parse(input, into: params)
-
-        params.merge(rest: rest)
-      end
-
-      def build_for_today(params)
         if params[:help]
           ShowHelp.new(parser)
         elsif params[:"list-tasks"] || params[:rest].empty?
@@ -29,6 +17,15 @@ module MicroManager
           task.merge!(due: params[:due]) if params[:due]
           AddTask.new(**task)
         end
+      end
+
+      private
+
+      def parse_input(input)
+        params = {}
+        rest = parser.parse(input, into: params)
+
+        params.merge(rest: rest)
       end
 
       def parser

--- a/lib/cli/relative_date.rb
+++ b/lib/cli/relative_date.rb
@@ -20,9 +20,9 @@ module MicroManager
 
       def self.date_offset(n, modifier)
         modifier_days = {
-          'day' => 1,
-          'week' => 7,
-          'month' => 30
+          "day" => 1,
+          "week" => 7,
+          "month" => 30
         } 
 
         n.to_i * modifier_days[modifier]

--- a/lib/cli/relative_date.rb
+++ b/lib/cli/relative_date.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module MicroManager
+  module CLI
+    class RelativeDate
+      def self.parse(string, *args) 
+        date = parse_relative_date(string)
+        return date if date
+
+        Date.parse(string, *args) 
+      end
+
+      def self.parse_relative_date(string)
+        regex = /(?<n>\d+)-(?<modifier>(day|week|month))/
+        matches = string.match(regex)
+        return unless matches
+
+        Date.today + date_offset(matches[:n], matches[:modifier])
+      end
+
+      def self.date_offset(n, modifier)
+        modifier_days = {
+          'day' => 1,
+          'week' => 7,
+          'month' => 30
+        } 
+
+        n.to_i * modifier_days[modifier]
+      end
+    end
+  end
+end

--- a/lib/cli/show_help.rb
+++ b/lib/cli/show_help.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module MicroManager
+  module CLI
+    class ShowHelp
+      private attr_reader :parser
+
+      def initialize(parser)
+        @parser = parser
+      end
+
+      def run(schedule:)
+        parser.banner = "Usage: just [task-description] [options]"
+
+        parser.help
+      end
+    end
+  end
+end

--- a/lib/micro_manager/schedule.rb
+++ b/lib/micro_manager/schedule.rb
@@ -14,7 +14,7 @@ module MicroManager
 
     def outstanding_tasks
       tasks
-        .select { |task| !task.completed? && task.due <= Date.today }
+        .select { |task| !task.completed? }
         .sort_by(&:due)
     end
     

--- a/micro_manager.gemspec
+++ b/micro_manager.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Bruno Vezoli"]
   spec.email         = ["brunvez@gmail.com"]
 
+  spec.license = "MIT"
+
   spec.summary       = "A utility to help get shit done"
   spec.description   = "A glorified TO-DO list with a couple of useful commands"
   spec.homepage      = "https://github.com/brunvez/micro_manager"
@@ -25,10 +27,4 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, checkout our
-  # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/spec/cli/command_builder_spec.rb
+++ b/spec/cli/command_builder_spec.rb
@@ -5,9 +5,36 @@ require_relative "../../lib/cli"
 module MicroManager
   module CLI
     RSpec.describe CommandBuilder do
+      it "buils a ShowHelp command when prompting for help" do
+        builder = CommandBuilder.new
+        input = ["--help"]
+
+        command = builder.build(input)
+        result = command.run(schedule: nil)
+
+        expect(command).to be_a(ShowHelp)
+        expect(result).to eq(
+          <<-HELP
+Usage: just [task-description] [options]
+    -d, --due [DATE]                 Date to which the task is due, defaults to Date.today. Supports relative dates (e.g. 1-day, 2-weeks, etc)
+    -l, --list-tasks                 Lists all due tasks and tasks completed today
+    -h, --help                       Prints this help
+          HELP
+        )
+      end
+
       it "builds a ListTasks command when there are no arguments" do
         builder = CommandBuilder.new
         input = []
+
+        command = builder.build(input)
+
+        expect(command).to be_a(ListTasks)
+      end
+
+      it "builds a ListTasks command when given --list-tasks input" do
+        builder = CommandBuilder.new
+        input = ["--list-tasks"]
 
         command = builder.build(input)
 
@@ -21,6 +48,49 @@ module MicroManager
         command = builder.build(input)
 
         expect(command).to be_a(AddTask)
+      end
+
+      it "can parse a due date" do
+        builder = CommandBuilder.new
+        input = ["Code some stuff", "--due", "2021-01-01"]
+        schedule = spy(Schedule)
+
+        command = builder.build(input)
+        command.run(schedule: schedule)
+
+        expect(schedule).to have_received(:add_task).with(description: "Code some stuff", due: Date.new(2021, 1, 1))
+      end
+
+      it "accepts a shorthand for the due date" do
+        builder = CommandBuilder.new
+        input = ["Code some stuff", "-d", "2021-01-01"]
+        schedule = spy(Schedule)
+
+        command = builder.build(input)
+        command.run(schedule: schedule)
+
+        expect(schedule).to have_received(:add_task).with(description: "Code some stuff", due: Date.new(2021, 1, 1))
+      end
+
+      it "allows sending time relative dates" do
+        dates = [
+          ["1-day", Date.today.next_day],
+          ["3-days", Date.today + 3],
+          ["1-week", Date.today + 7],
+          ["2-weeks", Date.today + 14],
+          ["1-month", Date.today + 30],
+          ["2-months", Date.today + 60]
+        ]
+        dates.each do |date_input, expected_date|
+          builder = CommandBuilder.new
+          input = ["Code some stuff due in #{date_input}", "-d", date_input]
+          schedule = spy(Schedule)
+
+          command = builder.build(input)
+          command.run(schedule: schedule)
+
+          expect(schedule).to have_received(:add_task).with(description: input.first, due: expected_date)
+        end
       end
 
       it "has a defualt of today for the due date" do

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -5,12 +5,13 @@ module MicroManager
     it "has a list of outstanding tasks" do
       outstanding_tasks = [
         Task.new(description: "Task 1", due: Date.today.prev_day),
-        Task.new(description: "Task 2", due: Date.today)
+        Task.new(description: "Task 2", due: Date.today),
+        Task.new(description: "Task 3", due: Date.today.next_day)
       ]
-      future_tasks = [
-        Task.new(description: "Task 2", due: Date.today.next_day)
-      ]
-      schedule = Schedule.new(tasks: outstanding_tasks + future_tasks)
+      completed_task = Task.new(description: "Task 4", due: Date.today)
+      schedule = Schedule.new(tasks: outstanding_tasks + [completed_task])
+
+      completed_task.complete
 
       expect(schedule.outstanding_tasks).to eq(outstanding_tasks)
     end


### PR DESCRIPTION
Add `-due` (`-d`) parameter to the command so as to be able to specify a task's due date.